### PR TITLE
AST: Variable declaration expression and other fixes

### DIFF
--- a/src/main/kotlin/marco/lang/AsmGenerator.kt
+++ b/src/main/kotlin/marco/lang/AsmGenerator.kt
@@ -53,6 +53,7 @@ class AsmGenerator(private val tokens: List<Token>) {
                     dataSection.append("\tstr_len_").append(strCount).append(" equ $-str_").append(strCount).append("\n")
                     strCount++
                 }
+                else -> println("Implement $token")
             }
         }
 

--- a/src/main/kotlin/marco/lang/AstBuilder.kt
+++ b/src/main/kotlin/marco/lang/AstBuilder.kt
@@ -20,9 +20,9 @@ class AstBuilder(private val tokens: List<Token>) {
                 }
                 TokenType.IDENTIFIER -> ast.add(parseIdentifier())
                 TokenType.KEYWORD -> {
-                    if (token.lex == "fn") {
+                    if (token.lex == Keywords.FUNCTION.lex) {
                         ast.add(parseFunction())
-                    } else if (token.lex == "var") {
+                    } else if (token.lex == Keywords.VARIABLE.lex) {
                         ast.add(parseVariableDeclaration())
                     }
                 }
@@ -52,7 +52,7 @@ class AstBuilder(private val tokens: List<Token>) {
     private fun parsePrimary(): ExpressionAst? {
         return when (getToken().type) {
             TokenType.KEYWORD -> {
-                if(getToken().lex == "ret") {
+                if(getToken().lex == Keywords.RETURN.lex) {
                     return parseReturn()
                 }
                 return null

--- a/src/main/kotlin/marco/lang/AstBuilder.kt
+++ b/src/main/kotlin/marco/lang/AstBuilder.kt
@@ -22,6 +22,8 @@ class AstBuilder(private val tokens: List<Token>) {
                 TokenType.KEYWORD -> {
                     if (token.lex == "fn") {
                         ast.add(parseFunction())
+                    } else if (token.lex == "var") {
+                        ast.add(parseVariableDeclaration())
                     }
                 }
                 TokenType.LP -> ast.add(parseParentisExpression())
@@ -38,6 +40,14 @@ class AstBuilder(private val tokens: List<Token>) {
     }
 
     private fun getToken(): Token = tokens[currentToken]
+
+    private fun parseVariableDeclaration(): VariableDeclarionAst {
+        assertCurrentToken(TokenType.KEYWORD)
+        val identifier = assertAndGetIdentifier()
+        assertCurrentToken(TokenType.EQ_BIND)
+        val expr = parseExpression()
+        return VariableDeclarionAst(identifier, expr!!)
+    }
 
     private fun parsePrimary(): ExpressionAst? {
         return when (getToken().type) {

--- a/src/main/kotlin/marco/lang/IDK.kt
+++ b/src/main/kotlin/marco/lang/IDK.kt
@@ -4,7 +4,15 @@ data class Token(val lex: String, val type: TokenType, val extra: Any? = null)
 
 data class StringExtra(val value: ByteArray)
 
-val keywords = listOf("var", "fn", "ret")
+enum class Keywords(val lex: String) {
+    VARIABLE("var"), FUNCTION("fn"), RETURN("ret");
+
+    companion object {
+        fun isValidKeyword(lex: String): Boolean {
+            return values().any { it.lex == lex }
+        }
+    }
+}
 
 enum class TokenType {
     KEYWORD, IDENTIFIER,

--- a/src/main/kotlin/marco/lang/Tokenizer.kt
+++ b/src/main/kotlin/marco/lang/Tokenizer.kt
@@ -99,7 +99,7 @@ class Tokenizer(input: String) {
             cursor++
         }
         val value = String(inputBytes.copyOfRange(start, cursor))
-        if (keywords.contains(value)) tokens.add(Token(value, TokenType.KEYWORD))
+        if (Keywords.isValidKeyword(value)) tokens.add(Token(value, TokenType.KEYWORD))
         else tokens.add(Token(value, TokenType.IDENTIFIER))
     }
 

--- a/src/main/kotlin/marco/lang/ast.kt
+++ b/src/main/kotlin/marco/lang/ast.kt
@@ -5,11 +5,12 @@ interface ExpressionAst
 data class NumberExpressionAst(val number: Double) : ExpressionAst
 data class StringExpressionAst(val string: String) : ExpressionAst
 data class VariableExpressionAst(val refName: String) : ExpressionAst
+data class VariableDeclarionAst(val refName: String, val value: ExpressionAst) : ExpressionAst
 data class BinaryExpressionAst(val left: ExpressionAst, val op: BinaryOp, val right: ExpressionAst) : ExpressionAst
-data class FunctionExpressionAst(val protoAst: PrototypeExpressionAst, val body: ExpressionAst): ExpressionAst
-data class ReturnExpressionAst(val ast: ExpressionAst): ExpressionAst
+data class FunctionExpressionAst(val protoAst: PrototypeExpressionAst, val body: ExpressionAst) : ExpressionAst
+data class ReturnExpressionAst(val ast: ExpressionAst) : ExpressionAst
 
-data class BodyExpressionAst(val stats: Array<ExpressionAst>): ExpressionAst {
+data class BodyExpressionAst(val stats: Array<ExpressionAst>) : ExpressionAst {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -39,6 +40,7 @@ data class CallExpressionAst(val name: String, val args: Array<ExpressionAst>) :
 
         return true
     }
+
     override fun hashCode(): Int {
         var result = name.hashCode()
         result = 31 * result + args.contentHashCode()
@@ -59,6 +61,7 @@ data class PrototypeExpressionAst(val name: String, val args: Array<String>) : E
 
         return true
     }
+
     override fun hashCode(): Int {
         var result = name.hashCode()
         result = 31 * result + args.contentHashCode()
@@ -76,7 +79,7 @@ enum class BinaryOp(val precedence: Int) {
 
     companion object {
         fun fromTokenType(tokenType: TokenType): BinaryOp {
-            return when(tokenType) {
+            return when (tokenType) {
                 TokenType.PLUS -> PLUS
                 TokenType.MINUS -> MINUS
                 TokenType.MUL -> MUL

--- a/src/test/kotlin/marco/lang/ast/BasicExpressionTest.kt
+++ b/src/test/kotlin/marco/lang/ast/BasicExpressionTest.kt
@@ -28,7 +28,7 @@ class BasicExpressionTest {
     }
 
     @Test
-    fun variable() {
+    fun identifier() {
         val src = "lang"
         val tokenizer = Tokenizer(src)
         tokenizer.run()
@@ -76,6 +76,20 @@ class BasicExpressionTest {
         assertEquals(1, astBuilder.ast.size)
         assertEquals(
             BinaryExpressionAst(NumberExpressionAst(34.0), BinaryOp.PLUS, NumberExpressionAst(35.0)),
+            astBuilder.ast[0]
+        )
+    }
+
+    @Test
+    fun variableDeclaration() {
+        val src = "var x = 69"
+        val tokenizer = Tokenizer(src)
+        tokenizer.run()
+        val astBuilder = AstBuilder(tokenizer.tokens)
+        astBuilder.build()
+        assertEquals(1, astBuilder.ast.size)
+        assertEquals(
+            VariableDeclarionAst("x", NumberExpressionAst(69.0)),
             astBuilder.ast[0]
         )
     }


### PR DESCRIPTION
### Done:

- Introduction of `VariableDeclarationExpression`. 

 Current syntax:
```
var x = 69
```
- Improve the keyword handling.
  - In the current setup the keyword is always checked with a string, this makes the job of changing keywords a lot worst.