### PR TITLE
AST: String on variable declarations.

### DIFF
--- a/src/main/kotlin/marco/lang/AstBuilder.kt
+++ b/src/main/kotlin/marco/lang/AstBuilder.kt
@@ -65,6 +65,11 @@ class AstBuilder(private val tokens: List<Token>) {
                 advance()
                 return NumberExpressionAst(value)
             }
+            TokenType.STRING -> {
+                val value = getToken().lex
+                advance()
+                return StringExpressionAst(value)
+            }
             else -> null
         }
     }


### PR DESCRIPTION
### Done:

- Fix the bug where String literals didn't get parsed when used in the Variable Declaration.
Example:
```
var string = "Hello World!";
```