### PR TITLE
AST: Fix expressions not being parsed on function bodies.

### DIFF
--- a/src/main/kotlin/marco/lang/AstBuilder.kt
+++ b/src/main/kotlin/marco/lang/AstBuilder.kt
@@ -8,44 +8,15 @@ class AstBuilder(private val tokens: List<Token>) {
 
     fun build() {
         while (currentToken < tokens.size - 1) {
-            val token = getToken()
-            when (token.type) {
-                TokenType.NUMBER -> {
-                    ast.add(parseExpression()!!)
-                    advance()
-                }
-                TokenType.STRING -> {
-                    ast.add(StringExpressionAst(token.lex))
-                    advance()
-                }
-                TokenType.IDENTIFIER -> ast.add(parseIdentifier())
-                TokenType.KEYWORD -> {
-                    when (token.lex) {
-                        Keywords.FUNCTION.lex -> {
-                            ast.add(parseFunction())
-                        }
-                        Keywords.VARIABLE.lex -> {
-                            ast.add(parseVariableDeclaration())
-                        }
-                        Keywords.WHILE.lex -> {
-                            ast.add(parseWhileLoop())
-                        }
-                        Keywords.IF.lex -> {
-                            ast.add(parseIf())
-                        }
-                        else -> {
-                            println("Implement keyword ${token.lex}")
-                        }
-                    }
-                }
-                TokenType.LP -> ast.add(parseParentisExpression())
-                else -> {
-                    println("Implement: $token")
-                    advance()
-                }
-            }
+            ast.add(parseExpression()!!)
         }
     }
+
+    private fun advance() {
+        if (currentToken + 1 < tokens.size) currentToken++
+    }
+
+    private fun getToken(): Token = tokens[currentToken]
 
     private fun parseIf(): IfExpressionAst {
         assertCurrentToken(TokenType.KEYWORD)
@@ -60,12 +31,6 @@ class AstBuilder(private val tokens: List<Token>) {
         return IfExpressionAst(condition, body, elseBody)
     }
 
-    private fun advance() {
-        if (currentToken + 1 < tokens.size) currentToken++
-    }
-
-    private fun getToken(): Token = tokens[currentToken]
-
     private fun parseVariableDeclaration(): VariableDeclarationAst {
         assertCurrentToken(TokenType.KEYWORD)
         val identifier = assertAndGetIdentifier()
@@ -79,15 +44,11 @@ class AstBuilder(private val tokens: List<Token>) {
         return when (getToken().type) {
             TokenType.KEYWORD -> {
                 when (getToken().lex) {
-                    Keywords.RETURN.lex -> {
-                        return parseReturn()
-                    }
-                    Keywords.WHILE.lex -> {
-                        return parseWhileLoop()
-                    }
-                    Keywords.IF.lex -> {
-                        return parseIf()
-                    }
+                    Keywords.RETURN.lex -> return parseReturn()
+                    Keywords.WHILE.lex -> return parseWhileLoop()
+                    Keywords.IF.lex -> return parseIf()
+                    Keywords.FUNCTION.lex -> return parseFunction()
+                    Keywords.VARIABLE.lex -> return parseVariableDeclaration()
                     else -> return null
                 }
             }

--- a/src/test/kotlin/marco/lang/ast/FunctionExpressionsTest.kt
+++ b/src/test/kotlin/marco/lang/ast/FunctionExpressionsTest.kt
@@ -88,4 +88,98 @@ class FunctionExpressionsTest {
         val astBuilder = AstBuilder(tokenizer.tokens)
         assertThrows<IllegalStateException> { astBuilder.build() }
     }
+
+    @Test
+    fun varDeclarationInsideFunc() {
+        val src = """
+            fn main(args) {
+                var x = 69;
+            }
+        """.trimIndent()
+        val tokenizer = Tokenizer(src)
+        tokenizer.run()
+        val astBuilder = AstBuilder(tokenizer.tokens)
+        astBuilder.build()
+        assertEquals(1, astBuilder.ast.size)
+        assertEquals(
+            FunctionExpressionAst(
+                PrototypeExpressionAst("main", arrayOf("args")),
+                BodyExpressionAst(
+                    arrayOf(
+                        VariableDeclarationAst("x", NumberExpressionAst(69.0))
+                    )
+                )
+            ),
+            astBuilder.ast[0]
+        )
+    }
+
+    @Test
+    fun controlFlowInsideFunc() {
+        val src = """
+            fn main(args) {
+                if a < 10 {
+                    print(a);
+                } else {
+                    print(b);
+                }
+            }
+        """.trimIndent()
+        val tokenizer = Tokenizer(src)
+        tokenizer.run()
+        val astBuilder = AstBuilder(tokenizer.tokens)
+        astBuilder.build()
+        assertEquals(1, astBuilder.ast.size)
+        assertEquals(
+            FunctionExpressionAst(
+                PrototypeExpressionAst("main", arrayOf("args")),
+                BodyExpressionAst(
+                    arrayOf(
+                        IfExpressionAst(
+                            BinaryExpressionAst(
+                                VariableExpressionAst("a"),
+                                BinaryOp.LT,
+                                NumberExpressionAst(10.0)
+                            ),
+                            BodyExpressionAst(arrayOf(CallExpressionAst("print", arrayOf(VariableExpressionAst("a"))))),
+                            BodyExpressionAst(arrayOf(CallExpressionAst("print", arrayOf(VariableExpressionAst("b")))))
+                        )
+                    )
+                )
+            ),
+            astBuilder.ast[0]
+        )
+    }
+
+    @Test
+    fun whileLoopInsideFunc() {
+        val src = """
+            fn main(args) {
+                while x < 10 {
+                    print(x);
+                }
+            }
+        """.trimIndent()
+        val tokenizer = Tokenizer(src)
+        tokenizer.run()
+        val astBuilder = AstBuilder(tokenizer.tokens)
+        astBuilder.build()
+        assertEquals(1, astBuilder.ast.size)
+        assertEquals(
+            FunctionExpressionAst(
+                PrototypeExpressionAst("main", arrayOf("args")),
+                BodyExpressionAst(arrayOf(
+                    WhileExpressionAst(
+                        BinaryExpressionAst(
+                            VariableExpressionAst("x"),
+                            BinaryOp.LT,
+                            NumberExpressionAst(10.0)
+                        ),
+                        BodyExpressionAst(arrayOf(CallExpressionAst("print", arrayOf(VariableExpressionAst("x"))))),
+                    )
+                ))
+            ),
+            astBuilder.ast[0]
+        )
+    }
 }


### PR DESCRIPTION
### Done:

- Fix expressions not being parsed on function bodies.

Example:
```
//This breaks because function bodies didn't parse variable declarations.
fn main(args) {
  var x = 10;
}
```